### PR TITLE
chore: release v0.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.0.2](https://github.com/beltram/sd-jwt/compare/v0.0.1...v0.0.2) - 2023-10-04
+
+### Other
+- *(deps)* bump actions/checkout from 3 to 4

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "selective-disclosure-jwt"
-version = "0.0.1"
+version = "0.0.2"
 edition = "2021"
 description = "Selective Disclosure JWTs"
 homepage = "https://github.com/beltram/sd-jwt"


### PR DESCRIPTION
## 🤖 New release
* `selective-disclosure-jwt`: 0.0.1 -> 0.0.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.0.2](https://github.com/beltram/sd-jwt/compare/v0.0.1...v0.0.2) - 2023-10-04

### Other
- *(deps)* bump actions/checkout from 3 to 4
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).