### PR TITLE
chore: release v0.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.3](https://github.com/beltram/sd-jwt/compare/v0.0.2...v0.0.3) - 2023-11-04
+
+### Added
+- simple issuer ready
+
 ## [0.0.2](https://github.com/beltram/sd-jwt/compare/v0.0.1...v0.0.2) - 2023-10-04
 
 ### Other

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "selective-disclosure-jwt"
-version = "0.0.2"
+version = "0.0.3"
 edition = "2021"
 description = "Selective Disclosure JWTs"
 homepage = "https://github.com/beltram/sd-jwt"


### PR DESCRIPTION
## 🤖 New release
* `selective-disclosure-jwt`: 0.0.2 -> 0.0.3 (⚠️ API breaking changes)

### ⚠️ `selective-disclosure-jwt` breaking changes

```
--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.24.2/src/lints/struct_missing.ron

Failed in:
  struct selective_disclosure_jwt::SDJwt, previously in file /tmp/.tmpYKUYXD/selective-disclosure-jwt/src/lib.rs:12
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.0.3](https://github.com/beltram/sd-jwt/compare/v0.0.2...v0.0.3) - 2023-11-04

### Added
- simple issuer ready
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).