### PR TITLE
chore: release v0.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.4](https://github.com/beltram/sd-jwt/compare/v0.0.3...v0.0.4) - 2023-11-06
+
+### Added
+- implement naive holder
+
 ## [0.0.3](https://github.com/beltram/sd-jwt/compare/v0.0.2...v0.0.3) - 2023-11-04
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "selective-disclosure-jwt"
-version = "0.0.3"
+version = "0.0.4"
 edition = "2021"
 description = "Selective Disclosure JWTs"
 homepage = "https://github.com/beltram/sd-jwt"


### PR DESCRIPTION
## 🤖 New release
* `selective-disclosure-jwt`: 0.0.3 -> 0.0.4 (⚠️ API breaking changes)

### ⚠️ `selective-disclosure-jwt` breaking changes

```
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.24.2/src/lints/constructible_struct_adds_field.ron

Failed in:
  field IssuerOptions.sign_alg in /tmp/.tmpkBgfQK/sd-jwt/src/issuer/options.rs:10

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.24.2/src/lints/enum_variant_added.ron

Failed in:
  variant SdjError:Base64Error in /tmp/.tmpkBgfQK/sd-jwt/src/error.rs:11
  variant SdjError:InvalidJsonPointerPath in /tmp/.tmpkBgfQK/sd-jwt/src/error.rs:17
  variant SdjError:InvalidSerializedSdJwt in /tmp/.tmpkBgfQK/sd-jwt/src/error.rs:19
  variant SdjError:InvalidJwt in /tmp/.tmpkBgfQK/sd-jwt/src/error.rs:21
  variant SdjError:UnknownDisclosure in /tmp/.tmpkBgfQK/sd-jwt/src/error.rs:23
  variant SdjError:InvalidDisclosure in /tmp/.tmpkBgfQK/sd-jwt/src/error.rs:25

--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.24.2/src/lints/inherent_method_missing.ron

Failed in:
  Issuer::try_generate_sdjwt, previously in file /tmp/.tmpwLgoSl/selective-disclosure-jwt/src/issuer/mod.rs:29
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.0.4](https://github.com/beltram/sd-jwt/compare/v0.0.3...v0.0.4) - 2023-11-06

### Added
- implement naive holder
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).